### PR TITLE
Update for tile release v2.1.3

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -52,23 +52,23 @@ The following table provides information about ForgeRock Service Broker version 
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v2.1.2</td>
+        <td>v2.1.3</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>June 28, 2019</td>
+        <td>February 29, 2020</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>ForgeRock Service Broker v2.0.2</td>
+        <td>ForgeRock Service Broker v2.0.3</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v2.3.x, v2.4.x and v2.6.x</td>
+        <td>v2.5.x, v2.6.x, v2.7.x and v2.8.x</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service version(s)</td>
-        <td>v2.3.x, v2.4.x and v2.6.x</td>
+        <td>v2.5.x, v2.6.x, v2.7.x and v2.8.x</td>
     </tr>
     <tr>
        <td>BOSH stemcell version</td>
@@ -76,7 +76,7 @@ The following table provides information about ForgeRock Service Broker version 
     </tr>
 </table>
 <p class="note warning"><strong> WARNING:</strong>
-ForgeRock Service Broker for PCF v2.0.2
+ForgeRock Service Broker for PCF v2.0.3
 and earlier require a Ubuntu Trusty stemcell.
 The end-of-life date for Ubuntu Trusty is April 2019.
 If a security vulnerability is found on this stemcell after April, it will not be fixed.</p>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -5,6 +5,14 @@ owner: Partners
 
 These are release notes for ForgeRock Service Broker for PCF.
 
+##<a id="ver"></a> v2.1.3
+
+**Release Date:** February 29, 2020
+
+Features included in this release:
+
+* Updated to v2.0.3 of the ForgeRock Service Broker to pick up a refresh of dependent ForgeRock Commons libraries.
+
 ##<a id="ver"></a> v2.1.2
 
 **Release Date:** June 28, 2019


### PR DESCRIPTION
A refresh of our ForgeRock tile, tested on pie-2-8-a.

Updated the Ops Manager and Service versions to what I think is more valid versions, happy to update as required.